### PR TITLE
Implemented delineEachLineFromFile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Implemented  `delineEachLineFromFile`.
 
 ## [v2.0.0] - 2016-10-07
 ### Removed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ To __deline__ a complete JSON Lines file back into JSON use the `delineFromFile`
 $json = (new JsonLines())->delineFromFile('/path/to/enlined.jsonl');
 ```
 
+To __deline__ a complete JSON Lines file line-by-line, use the `delineEachLineFromFile` method.
+```php
+$json_lines = (new JsonLines())->delineEachLineFromFile('/path/to/enlined.jsonl');
+foreach($json_lines as $json_line) var_dump($json_line);
+```
+This allows large file to be iterated over without storing the entire delined file in memory.
+
 #### Running tests
 ``` bash
 $ composer test

--- a/src/JsonLines.php
+++ b/src/JsonLines.php
@@ -164,4 +164,21 @@ class JsonLines
 
         return '[' . implode(',', $jsonLines) . ']';
     }
+    
+    /**
+     * Delines the next given JSON Lines file into JSON.
+     *
+     * @param  string $jsonLinesFile
+     * @throws NonReadable
+     * @return string
+     */
+    public function delineEachLineFromFile($jsonLinesFile)
+    {
+        $jsonLines = [];
+        foreach ($this->getFileLines($jsonLinesFile) as $line) {
+            $this->guardedJsonLine($line);
+            yield trim($line);
+        }
+
+    }
 }


### PR DESCRIPTION
I needed to loop through a large JSON Lines file. The `delineFromFile` command reads the whole file at once, and can cause an out of memory error with a large file. You already have a protected generator function `getFileLines` that yields the file line by line, and so I added a new public function `delineEachLineFromFile` which yields each delined file line.